### PR TITLE
Update dependency gem versions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,7 +13,7 @@ engines:
   fixme:
     enabled: false
   rubocop:
-    enabled: true
+    enabled: false
 ratings:
   paths:
   - Gemfile.lock

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,9 @@ Style/CollectionMethods:
 Style/Encoding:
   Enabled: false
 
+Style/IndentHeredoc:
+  Enabled: false
+
 # TODO(Darkpi):
 #   Enable this when rubocop fix the setter methods being reported.
 #   (https://github.com/bbatsov/rubocop/issues/4152)
@@ -56,6 +59,9 @@ Style/MethodCalledOnDoEndBlock:
 
 Style/OptionHash:
   Enabled: true
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
 
 Style/Send:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,7 @@ Style/Encoding:
   Enabled: false
 
 Style/EndOfLine:
-    EnforcedStyle: lf
+  EnforcedStyle: lf
 
 Style/IndentHeredoc:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,9 @@ Style/CollectionMethods:
 Style/Encoding:
   Enabled: false
 
+Style/EndOfLine:
+    EnforcedStyle: lf
+
 Style/IndentHeredoc:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://www.rubygems.org'
 
 gemspec
-
-gem 'dentaku', git: 'https://github.com/david942j/dentaku' # move to gemspec if this merged back to master :p

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,8 @@
-GIT
-  remote: https://github.com/david942j/dentaku
-  revision: 47bee012ea049d05767993cb8366986125e46ed1
-  specs:
-    dentaku (2.0.10)
-
 PATH
   remote: .
   specs:
     pwntools (0.1.0)
+      dentaku (~> 2.0.11)
       rainbow (~> 2.2)
 
 GEM
@@ -17,8 +12,9 @@ GEM
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.1)
+    dentaku (2.0.11)
     docile (1.1.5)
-    json (2.0.2)
+    json (2.1.0)
     method_source (0.8.2)
     minitest (5.10.1)
     parser (2.4.0.0)
@@ -28,7 +24,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rainbow (2.2.1)
+    rainbow (2.2.2)
+      rake
     rake (12.0.0)
     rubocop (0.47.1)
       parser (>= 2.3.3.1, < 3.0)
@@ -37,30 +34,29 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    simplecov (0.12.0)
+    simplecov (0.14.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
     tty-platform (0.1.0)
-    unicode-display_width (1.1.3)
-    yard (0.9.7)
+    unicode-display_width (1.2.1)
+    yard (0.9.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   codeclimate-test-reporter (~> 0.6)
-  dentaku!
   minitest (~> 5.8)
   pry (~> 0.10)
   pwntools!
   rake (~> 12.0)
-  rubocop (~> 0.47)
+  rubocop (= 0.47.1)
   simplecov (~> 0.12)
   tty-platform (~> 0.1)
   yard (~> 0.9)
 
 BUNDLED WITH
-   1.14.4
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.0.0)
-    rubocop (0.47.1)
+    rubocop (0.48.1)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
@@ -53,7 +53,7 @@ DEPENDENCIES
   pry (~> 0.10)
   pwntools!
   rake (~> 12.0)
-  rubocop (= 0.47.1)
+  rubocop (~> 0.47)
   simplecov (~> 0.12)
   tty-platform (~> 0.1)
   yard (~> 0.9)

--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,7 @@ end
 YARD::Rake::YardocTask.new(:doc)
 
 task :install_git_hooks do
+  next if ENV['CI']
   hooks = %w(pre-push)
   git_hook_dir = Pathname.new('.git/hooks/')
   hook_dir = Pathname.new('git-hooks/')

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,10 @@ install:
 
 build: off
 
+branches:
+  only:
+    - master
+
 before_test:
   - bundle exec ruby -v
   - bundle exec gem -v

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,24 @@
+version: 1.0.{build}-{branch}
+
+environment:
+  matrix:
+    - RUBY_VERSION: '21'
+    - RUBY_VERSION: '21-x64'
+    - RUBY_VERSION: '22'
+    - RUBY_VERSION: '22-x64'
+    - RUBY_VERSION: '23'
+    - RUBY_VERSION: '23-x64'
+
+install:
+  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - bundle install
+
+build: off
+
+before_test:
+  - bundle exec ruby -v
+  - bundle exec gem -v
+  - bundle -v
+
+test_script:
+  - bundle exec rake

--- a/pwntools.gemspec
+++ b/pwntools.gemspec
@@ -22,12 +22,13 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
 
   s.add_runtime_dependency 'rainbow', '~> 2.2'
+  s.add_runtime_dependency 'dentaku', '~> 2.0.11'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.6'
   s.add_development_dependency 'minitest', '~> 5.8'
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'rake', '~> 12.0'
-  s.add_development_dependency 'rubocop', '~> 0.47'
+  s.add_development_dependency 'rubocop', '= 0.47.1'
   s.add_development_dependency 'simplecov', '~> 0.12'
   s.add_development_dependency 'tty-platform', '~> 0.1'
   s.add_development_dependency 'yard', '~> 0.9'

--- a/pwntools.gemspec
+++ b/pwntools.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5.8'
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'rake', '~> 12.0'
-  s.add_development_dependency 'rubocop', '= 0.47.1'
+  s.add_development_dependency 'rubocop', '~> 0.47'
   s.add_development_dependency 'simplecov', '~> 0.12'
   s.add_development_dependency 'tty-platform', '~> 0.1'
   s.add_development_dependency 'yard', '~> 0.9'

--- a/test/util/hexdump_test.rb
+++ b/test/util/hexdump_test.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 # This test use UTF-8 encoding for strings since the output for hexdump contains lots of UTF-8 characters.
 
 require 'rainbow'


### PR DESCRIPTION
* Update dentaku to latest version (support bitwise operators). (Fix #25)
* Update some gems to latest version.
* Add `appveyor.yml` for testing ruby2.1-2.3 on windows.
* Skip installing git-hook on CI servers.

#### Note
There might be a warning raising in dentaku gem when running `rake test`:
`warning: loading in progress, circular require considered harmful`

It's a known issue and pull requested:
https://github.com/rubysolo/dentaku/pull/118

Comment out the first line in
```
vim $(dirname `gem which dentaku`)/dentaku/bulk_expression_solver.rb
```
`# require 'dentaku/calculator'` can fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/peter50216/pwntools-ruby/26)
<!-- Reviewable:end -->
