### PR TITLE
Fix pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -2,7 +2,7 @@ version: 2
 groups:
   code-review:
     approve_by_comment:
-      approve_regex: '^(Approved|:\+1:|LGTM)'
+      approve_regex: '^(Approved|:\+1:|LGTM|:lgtm:)'
       enabled: true
     required: 1
     reset_on_push:


### PR DESCRIPTION
Add :lgtm:, which is commented by Reviewable, to approve_regex

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/peter50216/pwntools-ruby/34)
<!-- Reviewable:end -->
