### PR TITLE
Upgrade dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,12 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
+Layout/EndOfLine:
+  EnforcedStyle: lf
+
+Layout/IndentHeredoc:
+  Enabled: false
+
 Metrics/AbcSize:
   Enabled: false
 
@@ -45,17 +51,16 @@ Style/CollectionMethods:
 Style/Encoding:
   Enabled: false
 
-Style/EndOfLine:
-  EnforcedStyle: lf
-
-Style/IndentHeredoc:
-  Enabled: false
-
-# TODO(Darkpi):
-#   Enable this when rubocop fix the setter methods being reported.
-#   (https://github.com/bbatsov/rubocop/issues/4152)
+# TODO(david942j):
+# `yield` cannot be ignored (didn't track why).
+# Enable this cop whenever its related bugs are fixed.
 # Style/MethodCallWithArgsParentheses:
 #   Enabled: true
+#   IgnoredMethods:
+#     - require
+#     - yield
+#     - skip
+#     - raise
 
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
@@ -77,3 +82,6 @@ Style/SymbolArray:
 
 Style/SingleLineBlockParams:
   Enabled: true
+
+Style/YodaCondition:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,8 +52,8 @@ Style/Encoding:
   Enabled: false
 
 # TODO(david942j):
-# `yield` cannot be ignored (didn't track why).
-# Enable this cop whenever its related bugs are fixed.
+#   `yield` cannot be ignored (didn't track why).
+#   Enable this cop whenever its related bugs are fixed.
 # Style/MethodCallWithArgsParentheses:
 #   Enabled: true
 #   IgnoredMethods:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       slop (~> 3.4)
     rainbow (2.2.2)
       rake
-    rake (12.0.0)
+    rake (12.1.0)
     rubocop (0.49.1)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -75,7 +75,7 @@ DEPENDENCIES
   minitest (= 5.10.1)
   pry (~> 0.10)
   pwntools!
-  rake (~> 12.0)
+  rake (~> 12.1)
   rubocop (~> 0.49)
   simplecov (~> 0.15)
   tty-platform (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
     json (2.1.0)
     method_source (0.8.2)
     minitest (5.10.1)
+    parallel (1.11.2)
     parser (2.4.0.0)
       ast (~> 2.2)
     powerpack (0.1.1)
@@ -46,21 +47,22 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.0.0)
-    rubocop (0.48.1)
+    rubocop (0.49.1)
+      parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    simplecov (0.14.1)
+    simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
+    simplecov-html (0.10.2)
     slop (3.6.0)
     tty-platform (0.1.0)
-    unicode-display_width (1.2.1)
+    unicode-display_width (1.3.0)
     yard (0.9.9)
 
 PLATFORMS
@@ -70,12 +72,12 @@ DEPENDENCIES
   codeclimate-test-reporter (~> 0.6)
   crabstone!
   keystone!
-  minitest (~> 5.8)
+  minitest (= 5.10.1)
   pry (~> 0.10)
   pwntools!
   rake (~> 12.0)
-  rubocop (~> 0.47)
-  simplecov (~> 0.12)
+  rubocop (~> 0.49)
+  simplecov (~> 0.15)
   tty-platform (~> 0.1)
   yard (~> 0.9)
 

--- a/lib/pwnlib/shellcraft/templates/i386/mov.rb
+++ b/lib/pwnlib/shellcraft/templates/i386/mov.rb
@@ -12,10 +12,10 @@ require 'pwnlib/util/packing'
 
   raise ArgumentError, "#{dest} is not a register" unless register?(dest)
   dest = get_register(dest)
-  raise ArgumentError "cannot use #{dest} on i386" if dest.size > 32 || dest.is64bit
+  raise ArgumentError, "cannot use #{dest} on i386" if dest.size > 32 || dest.is64bit
   if register?(src)
     src = get_register(src)
-    raise ArgumentError "cannot use #{src} on i386" if src.size > 32 || src.is64bit
+    raise ArgumentError, "cannot use #{src} on i386" if src.size > 32 || src.is64bit
     if dest.size < src.size && !dest.bigger.include?(src.name)
       raise ArgumentError, "cannot mov #{dest}, #{src}: dest is smaller than src"
     end

--- a/pwntools.gemspec
+++ b/pwntools.gemspec
@@ -29,11 +29,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'dentaku', '~> 2.0.11'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.6'
-  s.add_development_dependency 'minitest', '~> 5.8'
+  # ruby would crash during test if upgrade minitest to 5.10.3
+  s.add_development_dependency 'minitest', '= 5.10.1'
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'rake', '~> 12.0'
-  s.add_development_dependency 'rubocop', '~> 0.47'
-  s.add_development_dependency 'simplecov', '~> 0.12'
+  s.add_development_dependency 'rubocop', '~> 0.49'
+  s.add_development_dependency 'simplecov', '~> 0.15'
   s.add_development_dependency 'tty-platform', '~> 0.1'
   s.add_development_dependency 'yard', '~> 0.9'
 end

--- a/pwntools.gemspec
+++ b/pwntools.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'dentaku', '~> 2.0.11'
 
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.6'
-  # ruby would crash during test if upgrade minitest to 5.10.3
+  # TODO(david942j): check why ruby crash during testing if upgrade minitest to 5.10.2/3
   s.add_development_dependency 'minitest', '= 5.10.1'
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'rake', '~> 12.1'

--- a/pwntools.gemspec
+++ b/pwntools.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   # ruby would crash during test if upgrade minitest to 5.10.3
   s.add_development_dependency 'minitest', '= 5.10.1'
   s.add_development_dependency 'pry', '~> 0.10'
-  s.add_development_dependency 'rake', '~> 12.0'
+  s.add_development_dependency 'rake', '~> 12.1'
   s.add_development_dependency 'rubocop', '~> 0.49'
   s.add_development_dependency 'simplecov', '~> 0.15'
   s.add_development_dependency 'tty-platform', '~> 0.1'


### PR DESCRIPTION
### Upgraded
* rubocop to 0.49.1
* simplecov to 0.15.1
* rake to 12.1.0

#### Note
ruby would crash during testing if upgrade minitest to 5.10.2/3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/peter50216/pwntools-ruby/43)
<!-- Reviewable:end -->
