### PR TITLE
Fix return types of got/symbols and use logger in ELF class

### DIFF
--- a/lib/pwnlib/elf/elf.rb
+++ b/lib/pwnlib/elf/elf.rb
@@ -39,13 +39,14 @@ module Pwnlib
       #   # PIE:      PIE enabled
       #   #=> #<Pwnlib::ELF::ELF:0x00559bd670dcb8>
       def initialize(path, checksec: true)
+        path = File.realpath(path)
         @elf_file = ELFTools::ELFFile.new(File.open(path, 'rb')) # rubocop:disable Style/AutoResourceCleanup
         load_got
         load_plt
         load_symbols
         @address = base_address
         @load_addr = @address
-        show_info if checksec
+        show_info(path) if checksec
       end
 
       # Set the base address.
@@ -178,9 +179,9 @@ module Pwnlib
 
       private
 
-      def show_info
-        # TODO: Use logger?
-        puts checksec
+      def show_info(path)
+        log.info(path.inspect)
+        log.indented(checksec, level: ::Pwnlib::Logger::INFO)
       end
 
       # Get the dynamic tag with +type+.
@@ -254,8 +255,8 @@ module Pwnlib
                  .map { |seg| seg.header.p_vaddr }
                  .min
       end
-    end
 
-    include ::Pwnlib::Logger
+      include ::Pwnlib::Logger
+    end
   end
 end

--- a/test/elf/elf_test.rb
+++ b/test/elf/elf_test.rb
@@ -30,18 +30,18 @@ PIE:      No PIE (0x8048000)
   end
 
   def test_got
-    assert_equal(6, @elf.got.to_h.size)
-    assert_equal(0x8049774, @elf.got['__gmon_start__'])
-    assert_equal(0x8049774, @elf.got[:__gmon_start__])
-    assert_equal(0x8049778, @elf.symbols['_GLOBAL_OFFSET_TABLE_'])
-    assert_equal(0x804849b, @elf.symbols['main'])
-    assert_equal(@elf.symbols.main, @elf.symbols[:main])
+    assert_same(6, @elf.got.to_h.size)
+    assert_same(0x8049774, @elf.got['__gmon_start__'])
+    assert_same(0x8049774, @elf.got[:__gmon_start__])
+    assert_same(0x8049778, @elf.symbols['_GLOBAL_OFFSET_TABLE_'])
+    assert_same(0x804849b, @elf.symbols['main'])
+    assert_same(@elf.symbols.main, @elf.symbols[:main])
   end
 
   def test_plt
-    assert_equal(4, @elf.plt.to_h.size)
-    assert_equal(0x8048350, @elf.plt.printf)
-    assert_equal(0x8048370, @elf.plt[:setvbuf])
+    assert_same(4, @elf.plt.to_h.size)
+    assert_same(0x8048350, @elf.plt.printf)
+    assert_same(0x8048370, @elf.plt[:setvbuf])
   end
 
   def test_address


### PR DESCRIPTION
## Fix 
* got / symbols returned BinData types instead of Integer class, which will raise error if one invokes `flat(elf.got.printf)`.
* let `#plt` return `nil` instead of empty set if plt section not found.
* Remove two todos related to logger in ELF class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/peter50216/pwntools-ruby/44)
<!-- Reviewable:end -->
