### PR TITLE
Remove cache: bundler in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 sudo: required
-cache: bundler
 dist: trusty
 os:
 - linux


### PR DESCRIPTION
https://travis-ci.org/peter50216/pwntools-ruby/builds/427536869

Seems we can't use `cache: bundler` because ffi was compiled with elder Ruby version.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/peter50216/pwntools-ruby/129)
<!-- Reviewable:end -->
