### PR TITLE
Fix nested countdown test sometimes fail on appveyor

### DIFF
--- a/test/timer_test.rb
+++ b/test/timer_test.rb
@@ -34,7 +34,7 @@ class TimerTest < MiniTest::Test
   def test_nested_countdown_false_positve_115
     t = Timer.new
     assert_raises(::Pwnlib::Errors::TimeoutError) do
-      t.countdown(0.01) { sleep(0.02) }
+      t.countdown(0.01) { sleep(1) }
     end
     t.countdown(0.01) {}
   end


### PR DESCRIPTION
See: https://ci.appveyor.com/project/peter50216/pwntools-ruby/builds/20779755/job/fgtlfa551ryj982x

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/peter50216/pwntools-ruby/140)
<!-- Reviewable:end -->
