### PR TITLE
Let asm/disasm support more architectures

### DIFF
--- a/lib/pwnlib/asm.rb
+++ b/lib/pwnlib/asm.rb
@@ -210,24 +210,42 @@ module Pwnlib
         when 'mips' then Crabstone::MODE_MIPS32
         when 'mips64' then Crabstone::MODE_MIPS64
         when 'powerpc64' then Crabstone::MODE_64
-        when 'sparc' then 0 # default mode is enough
+        when 'sparc' then 0 # default mode
         when 'sparc64' then Crabstone::MODE_V9
         when 'thumb' then Crabstone::MODE_THUMB
-        end | (context.endian == 'little' ? Crabstone::MODE_LITTLE_ENDIAN : Crabstone::MODE_BIG_ENDIAN)
+        end | (context.endian == 'big' ? Crabstone::MODE_BIG_ENDIAN : Crabstone::MODE_LITTLE_ENDIAN)
       end
 
       def ks_arch
-        {
-          'i386' => KeystoneEngine::KS_ARCH_X86,
-          'amd64' => KeystoneEngine::KS_ARCH_X86
-        }[context.arch]
+        case context.arch
+        when 'aarch64' then KeystoneEngine::KS_ARCH_ARM64
+        when 'amd64' then KeystoneEngine::KS_ARCH_X86
+        when 'arm' then KeystoneEngine::KS_ARCH_ARM
+        when 'i386' then KeystoneEngine::KS_ARCH_X86
+        when 'mips' then KeystoneEngine::KS_ARCH_MIPS
+        when 'mips64' then KeystoneEngine::KS_ARCH_MIPS
+        when 'powerpc64' then KeystoneEngine::KS_ARCH_PPC
+        when 'sparc' then KeystoneEngine::KS_ARCH_SPARC
+        when 'sparc64' then KeystoneEngine::KS_ARCH_SPARC
+        when 'thumb' then KeystoneEngine::KS_ARCH_ARM
+        else raise ::Pwnlib::Errors::UnsupportedArchError,
+                   "Asm on architecture #{context.arch.inspect} is not supported yet."
+        end
       end
 
       def ks_mode
-        {
-          32 => KeystoneEngine::KS_MODE_32,
-          64 => KeystoneEngine::KS_MODE_64
-        }[context.bits]
+        case context.arch
+        when 'aarch64' then 0 # default mode
+        when 'amd64' then KeystoneEngine::KS_MODE_64
+        when 'arm' then KeystoneEngine::KS_MODE_ARM
+        when 'i386' then KeystoneEngine::KS_MODE_32
+        when 'mips' then KeystoneEngine::KS_MODE_MIPS32
+        when 'mips64' then KeystoneEngine::KS_MODE_MIPS64
+        when 'powerpc64' then KeystoneEngine::KS_MODE_PPC64
+        when 'sparc' then KeystoneEngine::KS_MODE_SPARC32
+        when 'sparc64' then KeystoneEngine::KS_MODE_SPARC64
+        when 'thumb' then KeystoneEngine::KS_MODE_THUMB
+        end | (context.endian == 'big' ? KeystoneEngine::KS_MODE_BIG_ENDIAN : KeystoneEngine::KS_MODE_LITTLE_ENDIAN)
       end
 
       # FFI is used in keystone and capstone binding gems, this method handles when libraries not installed yet.

--- a/lib/pwnlib/asm.rb
+++ b/lib/pwnlib/asm.rb
@@ -43,37 +43,38 @@ module Pwnlib
     # @example
     #   context.arch = 'i386'
     #   print disasm("\xb8\x5d\x00\x00\x00")
-    #   #   0:   b8 5d 00 00 00 mov     eax, 0x5d
+    #   #   0:   b8 5d 00 00 00  mov eax, 0x5d
     #
     #   context.arch = 'amd64'
     #   print disasm("\xb8\x17\x00\x00\x00")
     #   #   0:   b8 17 00 00 00 mov     eax, 0x17
     #   print disasm("jhH\xb8/bin///sPH\x89\xe71\xd21\xf6j;X\x0f\x05", vma: 0x1000)
-    #   #  1000:   6a 68                         push    0x68
-    #   #  1002:   48 b8 2f 62 69 6e 2f 2f 2f 73 movabs  rax, 0x732f2f2f6e69622f
-    #   #  100c:   50                            push    rax
-    #   #  100d:   48 89 e7                      mov     rdi, rsp
-    #   #  1010:   31 d2                         xor     edx, edx
-    #   #  1012:   31 f6                         xor     esi, esi
-    #   #  1014:   6a 3b                         push    0x3b
-    #   #  1016:   58                            pop     rax
-    #   #  1017:   0f 05                         syscall
+    #   #  1000:   6a 68                          push    0x68
+    #   #  1002:   48 b8 2f 62 69 6e 2f 2f 2f 73  movabs  rax, 0x732f2f2f6e69622f
+    #   #  100c:   50                             push    rax
+    #   #  100d:   48 89 e7                       mov     rdi, rsp
+    #   #  1010:   31 d2                          xor     edx, edx
+    #   #  1012:   31 f6                          xor     esi, esi
+    #   #  1014:   6a 3b                          push    0x3b
+    #   #  1016:   58                             pop     rax
+    #   #  1017:   0f 05                          syscall
     def disasm(data, vma: 0)
       require_message('crabstone', install_crabstone_guide) # will raise error if require fail.
       cs = Crabstone::Disassembler.new(cs_arch, cs_mode)
       insts = cs.disasm(data, vma).map do |ins|
-        [ins.address, ins.bytes.pack('C*'), ins.mnemonic, ins.op_str.to_s]
+        [ins.address, ins.bytes, ins.mnemonic.to_s, ins.op_str.to_s]
       end
       max_dlen = format('%x', insts.last.first).size + 2
       max_hlen = insts.map { |ins| ins[1].size }.max * 3
+      max_ilen = insts.map { |ins| ins[2].size }.max
       insts.reduce('') do |s, ins|
-        hex_code = ins[1].bytes.map { |c| format('%02x', c) }.join(' ')
+        hex_code = ins[1].map { |c| format('%02x', c) }.join(' ')
         inst = if ins[3].empty?
                  ins[2]
                else
-                 format('%-7s %s', ins[2], ins[3])
+                 format("%-#{max_ilen}s %s", ins[2], ins[3])
                end
-        s + format("%#{max_dlen}x:   %-#{max_hlen}s%s\n", ins[0], hex_code, inst)
+        s + format("%#{max_dlen}x:   %-#{max_hlen}s %s\n", ins[0], hex_code, inst)
       end
     end
 

--- a/lib/pwnlib/asm.rb
+++ b/lib/pwnlib/asm.rb
@@ -190,16 +190,14 @@ module Pwnlib
         when 'amd64' then Crabstone::ARCH_X86
         when 'arm' then Crabstone::ARCH_ARM
         when 'i386' then Crabstone::ARCH_X86
-        when 'm68k' then Crabstone::ARCH_M68K
         when 'mips' then Crabstone::ARCH_MIPS
         when 'mips64' then Crabstone::ARCH_MIPS
-        when 'powerpc' then Crabstone::ARCH_PPC
         when 'powerpc64' then Crabstone::ARCH_PPC
         when 'sparc' then Crabstone::ARCH_SPARC
         when 'sparc64' then Crabstone::ARCH_SPARC
         when 'thumb' then Crabstone::ARCH_ARM
         else raise ::Pwnlib::Errors::UnsupportedArchError,
-                   "Disassemble architecture #{context.arch.inspect} is not supported."
+                   "Disasm on architecture #{context.arch.inspect} is not supported yet."
         end
       end
 
@@ -209,16 +207,12 @@ module Pwnlib
         when 'amd64' then Crabstone::MODE_64
         when 'arm' then Crabstone::MODE_ARM
         when 'i386' then Crabstone::MODE_32
-        when 'm68k' then Crabstone::MODE_M68K_040 # XXX(david942j): Which mode should be used..?
         when 'mips' then Crabstone::MODE_MIPS32
         when 'mips64' then Crabstone::MODE_MIPS64
-        when 'powerpc' then Crabstone::MODE_32
         when 'powerpc64' then Crabstone::MODE_64
         when 'sparc' then 0 # default mode is enough
         when 'sparc64' then Crabstone::MODE_V9
         when 'thumb' then Crabstone::MODE_THUMB
-        else raise ::Pwnlib::Errors::UnsupportedArchError,
-                   "Disassemble architecture #{context.arch.inspect} is not supported."
         end | (context.endian == 'little' ? Crabstone::MODE_LITTLE_ENDIAN : Crabstone::MODE_BIG_ENDIAN)
       end
 

--- a/lib/pwnlib/asm.rb
+++ b/lib/pwnlib/asm.rb
@@ -187,17 +187,12 @@ module Pwnlib
       def cs_arch
         case context.arch
         when 'aarch64' then Crabstone::ARCH_ARM64
-        when 'amd64' then Crabstone::ARCH_X86
-        when 'arm' then Crabstone::ARCH_ARM
-        when 'i386' then Crabstone::ARCH_X86
-        when 'mips' then Crabstone::ARCH_MIPS
-        when 'mips64' then Crabstone::ARCH_MIPS
+        when 'amd64', 'i386' then Crabstone::ARCH_X86
+        when 'arm', 'thumb' then Crabstone::ARCH_ARM
+        when 'mips', 'mips64' then Crabstone::ARCH_MIPS
         when 'powerpc64' then Crabstone::ARCH_PPC
-        when 'sparc' then Crabstone::ARCH_SPARC
-        when 'sparc64' then Crabstone::ARCH_SPARC
-        when 'thumb' then Crabstone::ARCH_ARM
-        else raise ::Pwnlib::Errors::UnsupportedArchError,
-                   "Disasm on architecture #{context.arch.inspect} is not supported yet."
+        when 'sparc', 'sparc64' then Crabstone::ARCH_SPARC
+        else unsupported!("Disasm on architecture #{context.arch.inspect} is not supported yet.")
         end
       end
 
@@ -219,17 +214,12 @@ module Pwnlib
       def ks_arch
         case context.arch
         when 'aarch64' then KeystoneEngine::KS_ARCH_ARM64
-        when 'amd64' then KeystoneEngine::KS_ARCH_X86
-        when 'arm' then KeystoneEngine::KS_ARCH_ARM
-        when 'i386' then KeystoneEngine::KS_ARCH_X86
-        when 'mips' then KeystoneEngine::KS_ARCH_MIPS
-        when 'mips64' then KeystoneEngine::KS_ARCH_MIPS
-        when 'powerpc64' then KeystoneEngine::KS_ARCH_PPC
-        when 'sparc' then KeystoneEngine::KS_ARCH_SPARC
-        when 'sparc64' then KeystoneEngine::KS_ARCH_SPARC
-        when 'thumb' then KeystoneEngine::KS_ARCH_ARM
-        else raise ::Pwnlib::Errors::UnsupportedArchError,
-                   "Asm on architecture #{context.arch.inspect} is not supported yet."
+        when 'amd64', 'i386' then KeystoneEngine::KS_ARCH_X86
+        when 'arm', 'thumb' then KeystoneEngine::KS_ARCH_ARM
+        when 'mips', 'mips64' then KeystoneEngine::KS_ARCH_MIPS
+        when 'powerpc', 'powerpc64' then KeystoneEngine::KS_ARCH_PPC
+        when 'sparc', 'sparc64' then KeystoneEngine::KS_ARCH_SPARC
+        else unsupported!("Asm on architecture #{context.arch.inspect} is not supported yet.")
         end
       end
 
@@ -241,6 +231,7 @@ module Pwnlib
         when 'i386' then KeystoneEngine::KS_MODE_32
         when 'mips' then KeystoneEngine::KS_MODE_MIPS32
         when 'mips64' then KeystoneEngine::KS_MODE_MIPS64
+        when 'powerpc' then KeystoneEngine::KS_MODE_PPC32
         when 'powerpc64' then KeystoneEngine::KS_MODE_PPC64
         when 'sparc' then KeystoneEngine::KS_MODE_SPARC32
         when 'sparc64' then KeystoneEngine::KS_MODE_SPARC64
@@ -346,15 +337,17 @@ https://github.com/keystone-engine/keystone/tree/master/docs
 
       def e_machine
         const = ARCH_EM[context.arch.to_sym]
-        if const.nil?
-          raise ::Pwnlib::Errors::UnsupportedArchError,
-                "Unknown machine type of architecture #{context.arch.inspect}."
-        end
+        unsupported!("Unknown machine type of architecture #{context.arch.inspect}.") if const.nil?
+
         ::ELFTools::Constants::EM.const_get("EM_#{const}")
       end
 
       def endian
         context.endian.to_sym
+      end
+
+      def unsupported!(msg)
+        raise ::Pwnlib::Errors::UnsupportedArchError, msg
       end
 
       include ::Pwnlib::Context

--- a/test/asm_test.rb
+++ b/test/asm_test.rb
@@ -158,7 +158,7 @@ class AsmTest < MiniTest::Test
   # this test can be removed after method +run_shellcode+ being implemented
   def test_make_elf_and_run
     # run the ELF we created to make sure it works.
-    linux_only('ELF can only be executed on Linux')
+    linux_only 'ELF can only be executed on Linux'
 
     # test supported architecture
     {

--- a/test/asm_test.rb
+++ b/test/asm_test.rb
@@ -14,27 +14,19 @@ class AsmTest < MiniTest::Test
     @shellcraft = ::Pwnlib::Shellcraft::Shellcraft.instance
   end
 
-  def skip_windows
-    skip 'Not test asm/disasm on Windows' if TTY::Platform.new.windows?
-  end
-
-  def linux_only
-    skip 'ELF can only be executed on Linux' unless TTY::Platform.new.linux?
-  end
-
   def parse_sfile(filename)
     # First line is architecture
     lines = File.readlines(filename)
     metadata = lines.shift
-      .delete('#')
-      .split(',').map { |c| c.split(':', 2).map(&:strip) }
-      .map { |k, v| [k.to_sym, v] }
-      .to_h
+                    .delete('#')
+                    .split(',').map { |c| c.split(':', 2).map(&:strip) }
+                    .map { |k, v| [k.to_sym, v] }
+                    .to_h
     lines.reject { |l| l.start_with?('#') }.join.split("\n\n").each do |test|
       # fetch `<vma>:`
       vma = test.scan(/^\s*(\w+):/).flatten.first.to_i(16)
       # fetch bytes
-      bytes = [test.scan(/^\s*\w+:\s*(([\da-f]{2}\s)+)/).map(&:first).join.split.join].pack('H*')
+      bytes = [test.scan(/^\s*\w+:\s*(([\da-f]{2}\s)+)\s*[a-z]/).map(&:first).join.split.join].pack('H*')
       output = test
       output << "\n" unless output.end_with?("\n")
       yield(bytes, vma, test, **metadata)
@@ -197,7 +189,7 @@ class AsmTest < MiniTest::Test
   # this test can be removed after method +run_shellcode+ being implemented
   def test_make_elf_and_run
     # run the ELF we created to make sure it works.
-    linux_only
+    linux_only('ELF can only be executed on Linux')
 
     # test supported architecture
     {

--- a/test/asm_test.rb
+++ b/test/asm_test.rb
@@ -26,7 +26,7 @@ class AsmTest < MiniTest::Test
       # fetch `<vma>:`
       vma = test.scan(/^\s*(\w+):/).flatten.first.to_i(16)
       # fetch bytes
-      bytes = [test.scan(/^\s*\w+:\s*(([\da-f]{2}\s)+)\s*[a-z]/).map(&:first).join.split.join].pack('H*')
+      bytes = [test.scan(/^\s*\w+:\s{3}(([\da-f]{2}\s)+)\s/).map(&:first).join.split.join].pack('H*')
       output = test
       output << "\n" unless output.end_with?("\n")
       yield(bytes, vma, test, **metadata)
@@ -62,24 +62,24 @@ class AsmTest < MiniTest::Test
       str = Asm.disasm("h\x01\x01\x01\x01\x814$ri\x01\x011\xd2"\
                        "Rj\x04Z\x01\xe2R\x89\xe2jhh///sh/binj\x0bX\x89\xe3\x89\xd1\x99\xcd\x80")
       assert_equal(<<-EOS, str)
-   0:   68 01 01 01 01       push    0x1010101
-   5:   81 34 24 72 69 01 01 xor     dword ptr [esp], 0x1016972
-   c:   31 d2                xor     edx, edx
-   e:   52                   push    edx
-   f:   6a 04                push    4
-  11:   5a                   pop     edx
-  12:   01 e2                add     edx, esp
-  14:   52                   push    edx
-  15:   89 e2                mov     edx, esp
-  17:   6a 68                push    0x68
-  19:   68 2f 2f 2f 73       push    0x732f2f2f
-  1e:   68 2f 62 69 6e       push    0x6e69622f
-  23:   6a 0b                push    0xb
-  25:   58                   pop     eax
-  26:   89 e3                mov     ebx, esp
-  28:   89 d1                mov     ecx, edx
-  2a:   99                   cdq
-  2b:   cd 80                int     0x80
+   0:   68 01 01 01 01        push 0x1010101
+   5:   81 34 24 72 69 01 01  xor  dword ptr [esp], 0x1016972
+   c:   31 d2                 xor  edx, edx
+   e:   52                    push edx
+   f:   6a 04                 push 4
+  11:   5a                    pop  edx
+  12:   01 e2                 add  edx, esp
+  14:   52                    push edx
+  15:   89 e2                 mov  edx, esp
+  17:   6a 68                 push 0x68
+  19:   68 2f 2f 2f 73        push 0x732f2f2f
+  1e:   68 2f 62 69 6e        push 0x6e69622f
+  23:   6a 0b                 push 0xb
+  25:   58                    pop  eax
+  26:   89 e3                 mov  ebx, esp
+  28:   89 d1                 mov  ecx, edx
+  2a:   99                    cdq
+  2b:   cd 80                 int  0x80
       EOS
     end
   end
@@ -91,32 +91,32 @@ class AsmTest < MiniTest::Test
                        "Rj\x08ZH\x01\xe2RH\x89\xe2jhH\xb8/bin///sPj;XH\x89\xe7H\x89\xd6\x99\x0f\x05", vma: 0xfff)
 
       assert_equal(<<-EOS, str)
-   fff:   68 72 69 01 01                push    0x1016972
-  1004:   81 34 24 01 01 01 01          xor     dword ptr [rsp], 0x1010101
-  100b:   31 d2                         xor     edx, edx
-  100d:   52                            push    rdx
-  100e:   6a 08                         push    8
-  1010:   5a                            pop     rdx
-  1011:   48 01 e2                      add     rdx, rsp
-  1014:   52                            push    rdx
-  1015:   48 89 e2                      mov     rdx, rsp
-  1018:   6a 68                         push    0x68
-  101a:   48 b8 2f 62 69 6e 2f 2f 2f 73 movabs  rax, 0x732f2f2f6e69622f
-  1024:   50                            push    rax
-  1025:   6a 3b                         push    0x3b
-  1027:   58                            pop     rax
-  1028:   48 89 e7                      mov     rdi, rsp
-  102b:   48 89 d6                      mov     rsi, rdx
-  102e:   99                            cdq
-  102f:   0f 05                         syscall
+   fff:   68 72 69 01 01                 push    0x1016972
+  1004:   81 34 24 01 01 01 01           xor     dword ptr [rsp], 0x1010101
+  100b:   31 d2                          xor     edx, edx
+  100d:   52                             push    rdx
+  100e:   6a 08                          push    8
+  1010:   5a                             pop     rdx
+  1011:   48 01 e2                       add     rdx, rsp
+  1014:   52                             push    rdx
+  1015:   48 89 e2                       mov     rdx, rsp
+  1018:   6a 68                          push    0x68
+  101a:   48 b8 2f 62 69 6e 2f 2f 2f 73  movabs  rax, 0x732f2f2f6e69622f
+  1024:   50                             push    rax
+  1025:   6a 3b                          push    0x3b
+  1027:   58                             pop     rax
+  1028:   48 89 e7                       mov     rdi, rsp
+  102b:   48 89 d6                       mov     rsi, rdx
+  102e:   99                             cdq
+  102f:   0f 05                          syscall
       EOS
     end
   end
 
-  def test_disasm_all
-    skip_windows
-
-    Dir.glob(File.join(__dir__, 'data', 'assembly', '*.s')) do |file|
+  # Defining methods dynamically makes proper error message be shown when tests failed.
+  Dir.glob(File.join(__dir__, 'data', 'assembly', '*.s')) do |file|
+    __send__(:define_method, "test_disasm_file_#{File.basename(file, '.s')}") do
+      skip_windows
       count = 0
       parse_sfile(file) do |bytes, vma, output, **ctx|
         context.local(**ctx) do

--- a/test/asm_test.rb
+++ b/test/asm_test.rb
@@ -37,6 +37,7 @@ class AsmTest < MiniTest::Test
         vma, hex_code, _dummy, inst = l.scan(/^\s*(\w+):\s{3}(([\da-f]{2}\s)+)\s+(.*)$/).first
         [vma.to_i(16), hex_code.split.join, inst.strip]
       end
+
       vma = lines.first.first
       # concat all bytes
       bytes = [lines.map { |l| l[1] }.join].pack('H*')
@@ -46,11 +47,12 @@ class AsmTest < MiniTest::Test
   end
 
   # All tests of asm can be found under test/data/assembly/<arch>.s.
-  %w[aarch64 amd64 arm i386 mips mips64 powerpc64 sparc sparc64 thumb].each do |arch|
+  %w[aarch64 amd64 arm i386 mips mips64 powerpc powerpc64 sparc sparc64 thumb].each do |arch|
     file = File.join(__dir__, 'data', 'assembly', arch + '.s')
     # Defining methods dynamically makes proper error message shown when tests failed.
     __send__(:define_method, "test_asm_#{arch}") do
       skip_windows
+
       context.local(arch: arch) do
         parse_sfile(file) do |bytes, vma, insts, _output, comment, **ctx|
           next if comment.include?('!skip asm')
@@ -64,6 +66,8 @@ class AsmTest < MiniTest::Test
   end
 
   def test_asm_unsupported
+    skip_windows
+
     err = context.local(arch: :vax) do
       assert_raises(::Pwnlib::Errors::UnsupportedArchError) { Asm.asm('') }
     end
@@ -76,6 +80,7 @@ class AsmTest < MiniTest::Test
     # Defining methods dynamically makes proper error message shown when tests failed.
     __send__(:define_method, "test_disasm_#{arch}") do
       skip_windows
+
       context.local(arch: arch) do
         parse_sfile(file) do |bytes, vma, _insts, output, comment, **ctx|
           next if comment.include?('!skip disasm')
@@ -89,6 +94,8 @@ class AsmTest < MiniTest::Test
   end
 
   def test_disasm_unsupported
+    skip_windows
+
     err = context.local(arch: :vax) do
       assert_raises(::Pwnlib::Errors::UnsupportedArchError) { Asm.disasm('') }
     end

--- a/test/asm_test.rb
+++ b/test/asm_test.rb
@@ -56,65 +56,9 @@ class AsmTest < MiniTest::Test
     end
   end
 
-  def test_i386_disasm
-    skip_windows
-    context.local(arch: 'i386') do
-      str = Asm.disasm("h\x01\x01\x01\x01\x814$ri\x01\x011\xd2"\
-                       "Rj\x04Z\x01\xe2R\x89\xe2jhh///sh/binj\x0bX\x89\xe3\x89\xd1\x99\xcd\x80")
-      assert_equal(<<-EOS, str)
-   0:   68 01 01 01 01        push 0x1010101
-   5:   81 34 24 72 69 01 01  xor  dword ptr [esp], 0x1016972
-   c:   31 d2                 xor  edx, edx
-   e:   52                    push edx
-   f:   6a 04                 push 4
-  11:   5a                    pop  edx
-  12:   01 e2                 add  edx, esp
-  14:   52                    push edx
-  15:   89 e2                 mov  edx, esp
-  17:   6a 68                 push 0x68
-  19:   68 2f 2f 2f 73        push 0x732f2f2f
-  1e:   68 2f 62 69 6e        push 0x6e69622f
-  23:   6a 0b                 push 0xb
-  25:   58                    pop  eax
-  26:   89 e3                 mov  ebx, esp
-  28:   89 d1                 mov  ecx, edx
-  2a:   99                    cdq
-  2b:   cd 80                 int  0x80
-      EOS
-    end
-  end
-
-  def test_amd64_disasm
-    skip_windows
-    context.local(arch: 'amd64') do
-      str = Asm.disasm("hri\x01\x01\x814$\x01\x01\x01\x011\xd2" \
-                       "Rj\x08ZH\x01\xe2RH\x89\xe2jhH\xb8/bin///sPj;XH\x89\xe7H\x89\xd6\x99\x0f\x05", vma: 0xfff)
-
-      assert_equal(<<-EOS, str)
-   fff:   68 72 69 01 01                 push    0x1016972
-  1004:   81 34 24 01 01 01 01           xor     dword ptr [rsp], 0x1010101
-  100b:   31 d2                          xor     edx, edx
-  100d:   52                             push    rdx
-  100e:   6a 08                          push    8
-  1010:   5a                             pop     rdx
-  1011:   48 01 e2                       add     rdx, rsp
-  1014:   52                             push    rdx
-  1015:   48 89 e2                       mov     rdx, rsp
-  1018:   6a 68                          push    0x68
-  101a:   48 b8 2f 62 69 6e 2f 2f 2f 73  movabs  rax, 0x732f2f2f6e69622f
-  1024:   50                             push    rax
-  1025:   6a 3b                          push    0x3b
-  1027:   58                             pop     rax
-  1028:   48 89 e7                       mov     rdi, rsp
-  102b:   48 89 d6                       mov     rsi, rdx
-  102e:   99                             cdq
-  102f:   0f 05                          syscall
-      EOS
-    end
-  end
-
-  # Defining methods dynamically makes proper error message be shown when tests failed.
+  # All tests of disasm can be found under test/data/assembly/<arch>.s.
   Dir.glob(File.join(__dir__, 'data', 'assembly', '*.s')) do |file|
+    # Defining methods dynamically makes proper error message shown when tests failed.
     __send__(:define_method, "test_disasm_file_#{File.basename(file, '.s')}") do
       skip_windows
       parse_sfile(file) do |bytes, vma, output, **ctx|
@@ -123,6 +67,13 @@ class AsmTest < MiniTest::Test
         end
       end
     end
+  end
+
+  def test_disasm_unsupported
+    err = context.local(arch: :vax) do
+      assert_raises(::Pwnlib::Errors::UnsupportedArchError) { Asm.disasm('') }
+    end
+    assert_equal('Disasm on architecture "vax" is not supported yet.', err.message)
   end
 
   # To ensure coverage

--- a/test/asm_test.rb
+++ b/test/asm_test.rb
@@ -117,15 +117,11 @@ class AsmTest < MiniTest::Test
   Dir.glob(File.join(__dir__, 'data', 'assembly', '*.s')) do |file|
     __send__(:define_method, "test_disasm_file_#{File.basename(file, '.s')}") do
       skip_windows
-      count = 0
       parse_sfile(file) do |bytes, vma, output, **ctx|
         context.local(**ctx) do
           assert_equal(output, Asm.disasm(bytes, vma: vma))
-          count += 1
         end
       end
-      # At least one example being tested in one .s file.
-      assert(count.positive?)
     end
   end
 

--- a/test/data/assembly/aarch64.s
+++ b/test/data/assembly/aarch64.s
@@ -1,4 +1,3 @@
-# arch: aarch64
 # These tests are fetched from Capstone's test_arm64.c
 # ARM-64
   2c:   09 00 38 d5  mrs   x9, midr_el1

--- a/test/data/assembly/aarch64.s
+++ b/test/data/assembly/aarch64.s
@@ -1,0 +1,20 @@
+# arch: aarch64
+# These tests are fetched from Capstone's test_arm64.c
+# ARM-64
+  2c:   09 00 38 d5  mrs   x9, midr_el1
+  30:   bf 40 00 d5  msr   spsel, #0
+  34:   0c 05 13 d5  msr   dbgdtrtx_el0, x12
+  38:   20 50 02 0e  tbx   v0.8b, {v1.16b, v2.16b, v3.16b}, v2.8b
+  3c:   20 e4 3d 0f  scvtf v0.2s, v1.2s, #3
+  40:   00 18 a0 5f  fmla  s0, s0, v0.s[3]
+  44:   a2 00 ae 9e  fmov  x2, v5.d[1]
+  48:   9f 37 03 d5  dsb   nsh
+  4c:   bf 33 03 d5  dmb   osh
+  50:   df 3f 03 d5  isb
+  54:   21 7c 02 9b  mul   x1, x1, x2
+  58:   21 7c 00 53  lsr   w1, w1, #0
+  5c:   00 40 21 4b  sub   w0, w0, w1, uxtw
+  60:   e1 0b 40 b9  ldr   w1, [sp, #8]
+  64:   20 04 81 da  cneg  x0, x1, ne
+  68:   20 08 02 8b  add   x0, x1, x2, lsl #2
+  6c:   10 5b e8 3c  ldr   q16, [x24, w8, uxtw #4]

--- a/test/data/assembly/amd64.s
+++ b/test/data/assembly/amd64.s
@@ -1,0 +1,22 @@
+# arch: amd64
+# simple move
+  0:   b8 17 00 00 00 mov     eax, 0x17
+
+# pwntools-python's shellcraft.sh()
+   0:   6a 68                         push    0x68
+   2:   48 b8 2f 62 69 6e 2f 2f 2f 73 movabs  rax, 0x732f2f2f6e69622f
+   c:   50                            push    rax
+   d:   48 89 e7                      mov     rdi, rsp
+  10:   68 72 69 01 01                push    0x1016972
+  15:   81 34 24 01 01 01 01          xor     dword ptr [rsp], 0x1010101
+  1c:   31 f6                         xor     esi, esi
+  1e:   56                            push    rsi
+  1f:   6a 08                         push    8
+  21:   5e                            pop     rsi
+  22:   48 01 e6                      add     rsi, rsp
+  25:   56                            push    rsi
+  26:   48 89 e6                      mov     rsi, rsp
+  29:   31 d2                         xor     edx, edx
+  2b:   6a 3b                         push    0x3b
+  2d:   58                            pop     rax
+  2e:   0f 05                         syscall

--- a/test/data/assembly/amd64.s
+++ b/test/data/assembly/amd64.s
@@ -1,22 +1,22 @@
 # arch: amd64
 # simple move
-  0:   b8 17 00 00 00 mov     eax, 0x17
+  0:   b8 17 00 00 00  mov eax, 0x17
 
 # pwntools-python's shellcraft.sh()
-   0:   6a 68                         push    0x68
-   2:   48 b8 2f 62 69 6e 2f 2f 2f 73 movabs  rax, 0x732f2f2f6e69622f
-   c:   50                            push    rax
-   d:   48 89 e7                      mov     rdi, rsp
-  10:   68 72 69 01 01                push    0x1016972
-  15:   81 34 24 01 01 01 01          xor     dword ptr [rsp], 0x1010101
-  1c:   31 f6                         xor     esi, esi
-  1e:   56                            push    rsi
-  1f:   6a 08                         push    8
-  21:   5e                            pop     rsi
-  22:   48 01 e6                      add     rsi, rsp
-  25:   56                            push    rsi
-  26:   48 89 e6                      mov     rsi, rsp
-  29:   31 d2                         xor     edx, edx
-  2b:   6a 3b                         push    0x3b
-  2d:   58                            pop     rax
-  2e:   0f 05                         syscall
+   0:   6a 68                          push    0x68
+   2:   48 b8 2f 62 69 6e 2f 2f 2f 73  movabs  rax, 0x732f2f2f6e69622f
+   c:   50                             push    rax
+   d:   48 89 e7                       mov     rdi, rsp
+  10:   68 72 69 01 01                 push    0x1016972
+  15:   81 34 24 01 01 01 01           xor     dword ptr [rsp], 0x1010101
+  1c:   31 f6                          xor     esi, esi
+  1e:   56                             push    rsi
+  1f:   6a 08                          push    8
+  21:   5e                             pop     rsi
+  22:   48 01 e6                       add     rsi, rsp
+  25:   56                             push    rsi
+  26:   48 89 e6                       mov     rsi, rsp
+  29:   31 d2                          xor     edx, edx
+  2b:   6a 3b                          push    0x3b
+  2d:   58                             pop     rax
+  2e:   0f 05                          syscall

--- a/test/data/assembly/amd64.s
+++ b/test/data/assembly/amd64.s
@@ -1,4 +1,3 @@
-# arch: amd64
 # simple move
   0:   b8 17 00 00 00  mov eax, 0x17
 

--- a/test/data/assembly/arm.s
+++ b/test/data/assembly/arm.s
@@ -1,0 +1,10 @@
+# arch: arm
+# These tests are fetched from Capstone's test_arm.c
+  1000:   ed ff ff eb  bl    #0xfbc
+  1004:   04 e0 2d e5  str   lr, [sp, #-4]!
+  1008:   00 00 00 00  andeq r0, r0, r0
+  100c:   e0 83 22 e5  str   r8, [r2, #-0x3e0]!
+  1010:   f1 02 03 0e  mcreq p2, #0, r0, c3, c1, #7
+  1014:   00 00 a0 e3  mov   r0, #0
+  1018:   02 30 c1 e7  strb  r3, [r1, r2]
+  101c:   00 00 53 e3  cmp   r3, #0

--- a/test/data/assembly/arm.s
+++ b/test/data/assembly/arm.s
@@ -1,4 +1,3 @@
-# arch: arm
 # These tests are fetched from Capstone's test_arm.c
   1000:   ed ff ff eb  bl    #0xfbc
   1004:   04 e0 2d e5  str   lr, [sp, #-4]!

--- a/test/data/assembly/i386.s
+++ b/test/data/assembly/i386.s
@@ -1,22 +1,22 @@
 # arch: i386
 # simple move
-  0:   b8 5d 00 00 00 mov     eax, 0x5d
+  0:   b8 5d 00 00 00  mov eax, 0x5d
 
 # pwntools-python's shellcraft.sh()
-   0:   6a 68                push    0x68
-   2:   68 2f 2f 2f 73       push    0x732f2f2f
-   7:   68 2f 62 69 6e       push    0x6e69622f
-   c:   89 e3                mov     ebx, esp
-   e:   68 01 01 01 01       push    0x1010101
-  13:   81 34 24 72 69 01 01 xor     dword ptr [esp], 0x1016972
-  1a:   31 c9                xor     ecx, ecx
-  1c:   51                   push    ecx
-  1d:   6a 04                push    4
-  1f:   59                   pop     ecx
-  20:   01 e1                add     ecx, esp
-  22:   51                   push    ecx
-  23:   89 e1                mov     ecx, esp
-  25:   31 d2                xor     edx, edx
-  27:   6a 0b                push    0xb
-  29:   58                   pop     eax
-  2a:   cd 80                int     0x80
+   0:   6a 68                 push 0x68
+   2:   68 2f 2f 2f 73        push 0x732f2f2f
+   7:   68 2f 62 69 6e        push 0x6e69622f
+   c:   89 e3                 mov  ebx, esp
+   e:   68 01 01 01 01        push 0x1010101
+  13:   81 34 24 72 69 01 01  xor  dword ptr [esp], 0x1016972
+  1a:   31 c9                 xor  ecx, ecx
+  1c:   51                    push ecx
+  1d:   6a 04                 push 4
+  1f:   59                    pop  ecx
+  20:   01 e1                 add  ecx, esp
+  22:   51                    push ecx
+  23:   89 e1                 mov  ecx, esp
+  25:   31 d2                 xor  edx, edx
+  27:   6a 0b                 push 0xb
+  29:   58                    pop  eax
+  2a:   cd 80                 int  0x80

--- a/test/data/assembly/i386.s
+++ b/test/data/assembly/i386.s
@@ -1,0 +1,22 @@
+# arch: i386
+# simple move
+  0:   b8 5d 00 00 00 mov     eax, 0x5d
+
+# pwntools-python's shellcraft.sh()
+   0:   6a 68                push    0x68
+   2:   68 2f 2f 2f 73       push    0x732f2f2f
+   7:   68 2f 62 69 6e       push    0x6e69622f
+   c:   89 e3                mov     ebx, esp
+   e:   68 01 01 01 01       push    0x1010101
+  13:   81 34 24 72 69 01 01 xor     dword ptr [esp], 0x1016972
+  1a:   31 c9                xor     ecx, ecx
+  1c:   51                   push    ecx
+  1d:   6a 04                push    4
+  1f:   59                   pop     ecx
+  20:   01 e1                add     ecx, esp
+  22:   51                   push    ecx
+  23:   89 e1                mov     ecx, esp
+  25:   31 d2                xor     edx, edx
+  27:   6a 0b                push    0xb
+  29:   58                   pop     eax
+  2a:   cd 80                int     0x80

--- a/test/data/assembly/i386.s
+++ b/test/data/assembly/i386.s
@@ -1,4 +1,3 @@
-# arch: i386
 # simple move
   0:   b8 5d 00 00 00  mov eax, 0x5d
 

--- a/test/data/assembly/mips.s
+++ b/test/data/assembly/mips.s
@@ -1,8 +1,16 @@
-# arch: mips, endian: big
 # These tests are fetched from Capstone's test_mips.c
+
+# context: endian: big
+# !skip asm # because of keystone-engine/keystone#405
 # MIPS-32 (Big-endian)
   1000:   0c 10 00 97  jal   0x40025c
   1004:   00 00 00 00  nop
+  1008:   24 02 00 0c  addiu $v0, $zero, 0xc
+  100c:   8f a2 00 00  lw    $v0, ($sp)
+  1010:   34 21 34 56  ori   $at, $at, 0x3456
+
+# context: endian: big
+# Copied from above, ignored branch instructions
   1008:   24 02 00 0c  addiu $v0, $zero, 0xc
   100c:   8f a2 00 00  lw    $v0, ($sp)
   1010:   34 21 34 56  ori   $at, $at, 0x3456

--- a/test/data/assembly/mips.s
+++ b/test/data/assembly/mips.s
@@ -1,0 +1,8 @@
+# arch: mips, endian: big
+# These tests are fetched from Capstone's test_mips.c
+# MIPS-32 (Big-endian)
+  1000:   0c 10 00 97  jal   0x40025c
+  1004:   00 00 00 00  nop
+  1008:   24 02 00 0c  addiu $v0, $zero, 0xc
+  100c:   8f a2 00 00  lw    $v0, ($sp)
+  1010:   34 21 34 56  ori   $at, $at, 0x3456

--- a/test/data/assembly/mips64.s
+++ b/test/data/assembly/mips64.s
@@ -1,0 +1,6 @@
+# arch: mips64
+# These tests are fetched from Capstone's test_mips.c
+# MIPS-64-EL (Little-endian)
+  1000:   56 34 21 34  ori $at, $at, 0x3456
+  1004:   c2 17 01 00  srl $v0, $at, 0x1f
+  1008:   70 00 b2 ff  sd  $s2, 0x70($sp)

--- a/test/data/assembly/mips64.s
+++ b/test/data/assembly/mips64.s
@@ -1,4 +1,4 @@
-# arch: mips64
+# context: endian: little
 # These tests are fetched from Capstone's test_mips.c
 # MIPS-64-EL (Little-endian)
   1000:   56 34 21 34  ori $at, $at, 0x3456

--- a/test/data/assembly/powerpc.s
+++ b/test/data/assembly/powerpc.s
@@ -1,0 +1,18 @@
+# context: endian: big
+# This test is (almost) same as powerpc64.s
+  1000:   43 20 0c 07  bdnzla+  0xc04
+  1004:   41 56 ff 17  bdztla   4*cr5+eq, 0xffffffffffffff14
+  1008:   80 20 00 00  lwz      1, 0(0)
+  1010:   80 3f 00 00  lwz      1, 0(31)
+  1014:   10 43 23 0e  vpkpx    2, 3, 4
+  1018:   d0 44 00 80  stfs     2, 0x80(4)
+  101c:   4c 43 22 02  crand    2, 3, 4
+  1020:   2d 03 00 80  cmpwi    cr2, 3, 0x80
+  1024:   7c 43 20 14  addc     2, 3, 4
+  1028:   7c 43 20 93  mulhd.   2, 3, 4
+  102c:   4f 20 00 21  bdnzlrl+
+  1030:   4c c8 00 21  bgelrl-  cr2
+  1034:   40 82 00 14  bne      0x1044
+
+# This instruction in ppc32 only
+  0:   7c 21 04 a6  mfsr 1, 1

--- a/test/data/assembly/powerpc64.s
+++ b/test/data/assembly/powerpc64.s
@@ -1,11 +1,13 @@
-# arch: powerpc64, endian: big
 # These tests are fetched from Capstone's test_ppc.c
+
+# context: endian: big
+# !skip asm
 # PPC-64
   1000:   43 20 0c 07  bdnzla+  0xc04
   1004:   41 56 7f 17  bdztla   4*cr5+eq, 0x7f14
 # Inconsistent output between capstone3 and later versions, skip
-#  1008:   80 20 00 00  lwz      r1, 0(0)
-#  100c:   80 3f 00 00  lwz      r1, 0(r31)
+  ; 1008:   80 20 00 00  lwz      r1, 0(0)
+  ; 100c:   80 3f 00 00  lwz      r1, 0(r31)
   1008:   10 43 23 0e  vpkpx    v2, v3, v4
   100c:   d0 44 00 80  stfs     f2, 0x80(r4)
   1010:   4c 43 22 02  crand    2, 3, 4
@@ -15,3 +17,20 @@
   1020:   4f 20 00 21  bdnzlrl+
   1024:   4c c8 00 21  bgelrl-  cr2
   1028:   40 82 00 14  bne      0x103c
+
+# context: endian: big
+# !skip disasm
+# PPC-64
+  1000:   43 20 0c 07  bdnzla+  0xc04
+  1004:   41 56 7f 17  bdztla   4*cr5+eq, 0x7f14
+  1008:   80 20 00 00  lwz      1, 0(0)
+  1010:   80 3f 00 00  lwz      1, 0(31)
+  1014:   10 43 23 0e  vpkpx    2, 3, 4
+  1018:   d0 44 00 80  stfs     2, 0x80(4)
+  101c:   4c 43 22 02  crand    2, 3, 4
+  1020:   2d 03 00 80  cmpwi    cr2, 3, 0x80
+  1024:   7c 43 20 14  addc     2, 3, 4
+  1028:   7c 43 20 93  mulhd.   2, 3, 4
+  102c:   4f 20 00 21  bdnzlrl+
+  1030:   4c c8 00 21  bgelrl-  cr2
+  1034:   40 82 00 14  bne      0x1044

--- a/test/data/assembly/powerpc64.s
+++ b/test/data/assembly/powerpc64.s
@@ -1,0 +1,17 @@
+# arch: powerpc64, endian: big
+# These tests are fetched from Capstone's test_ppc.c
+# PPC-64
+  1000:   43 20 0c 07  bdnzla+  0xc04
+  1004:   41 56 7f 17  bdztla   4*cr5+eq, 0x7f14
+# Inconsistent output between capstone3 and later versions, skip
+#  1008:   80 20 00 00  lwz      r1, 0(0)
+#  100c:   80 3f 00 00  lwz      r1, 0(r31)
+  1008:   10 43 23 0e  vpkpx    v2, v3, v4
+  100c:   d0 44 00 80  stfs     f2, 0x80(r4)
+  1010:   4c 43 22 02  crand    2, 3, 4
+  1014:   2d 03 00 80  cmpwi    cr2, r3, 0x80
+  1018:   7c 43 20 14  addc     r2, r3, r4
+  101c:   7c 43 20 93  mulhd.   r2, r3, r4
+  1020:   4f 20 00 21  bdnzlrl+
+  1024:   4c c8 00 21  bgelrl-  cr2
+  1028:   40 82 00 14  bne      0x103c

--- a/test/data/assembly/sparc.s
+++ b/test/data/assembly/sparc.s
@@ -1,18 +1,33 @@
-# arch: sparc
 # These tests are fetched from Capstone's test_sparc.c
-  1000:   80 a0 40 02  cmp       %g1, %g2
-  1004:   85 c2 60 08  jmpl      %o1+8, %g2
-  1008:   85 e8 20 01  restore   %g0, 1, %g2
+
+# !skip asm # because of keystone-engine/keystone#405
+  1000:   80 a0 40 02  cmp     %g1, %g2
+  1004:   85 c2 60 08  jmpl    %o1+8, %g2
+  1008:   85 e8 20 01  restore %g0, 1, %g2
   100c:   81 e8 00 00  restore
-  1010:   90 10 20 01  mov       1, %o0
-  1014:   d5 f6 10 16  casx      [%i0], %l6, %o2
-  1018:   21 00 00 0a  sethi     0xa, %l0
-  101c:   86 00 40 02  add       %g1, %g2, %g3
+  1010:   90 10 20 01  mov     1, %o0
+  1014:   d5 f6 10 16  casx    [%i0], %l6, %o2
+  1018:   21 00 00 0a  sethi   0xa, %l0
+  101c:   86 00 40 02  add     %g1, %g2, %g3
   1020:   01 00 00 00  nop
-  1024:   12 bf ff ff  bne       0x1020
-  1028:   10 bf ff ff  ba        0x1024
-  102c:   a0 02 00 09  add       %o0, %o1, %l0
-  1030:   0d bf ff ff  fbg       0x102c
-  1034:   d4 20 60 00  st        %o2, [%g1]
-  1038:   d4 4e 00 16  ldsb      [%i0+%l6], %o2
-  103c:   2a c2 80 03  brnz,a,pn %o2, 0x1048
+  1024:   12 bf ff ff  bne     0x1020
+  1028:   10 bf ff ff  ba      0x1024
+  102c:   a0 02 00 09  add     %o0, %o1, %l0
+  1030:   0d bf ff ff  fbg     0x102c
+  1034:   d4 20 40 00  st      %o2, [%g1]
+  1038:   d4 4e 00 16  ldsb    [%i0+%l6], %o2
+# The output between objdump/llvm/capstone is inconsistent
+  ; 103c:   2a c2 80 03  brnz,a,pn %o2, 0x1048
+
+# Copied from above, ignored branch instructions
+  1000:   80 a0 40 02  cmp     %g1, %g2
+  1004:   85 e8 20 01  restore %g0, 1, %g2
+  1008:   81 e8 00 00  restore
+  100c:   90 10 20 01  mov     1, %o0
+  1010:   d5 f6 10 16  casx    [%i0], %l6, %o2
+  1014:   21 00 00 0a  sethi   0xa, %l0
+  1018:   86 00 40 02  add     %g1, %g2, %g3
+  101c:   01 00 00 00  nop
+  1020:   a0 02 00 09  add     %o0, %o1, %l0
+  1024:   d4 20 40 00  st      %o2, [%g1]
+  1028:   d4 4e 00 16  ldsb    [%i0+%l6], %o2

--- a/test/data/assembly/sparc.s
+++ b/test/data/assembly/sparc.s
@@ -1,0 +1,18 @@
+# arch: sparc
+# These tests are fetched from Capstone's test_sparc.c
+  1000:   80 a0 40 02  cmp       %g1, %g2
+  1004:   85 c2 60 08  jmpl      %o1+8, %g2
+  1008:   85 e8 20 01  restore   %g0, 1, %g2
+  100c:   81 e8 00 00  restore
+  1010:   90 10 20 01  mov       1, %o0
+  1014:   d5 f6 10 16  casx      [%i0], %l6, %o2
+  1018:   21 00 00 0a  sethi     0xa, %l0
+  101c:   86 00 40 02  add       %g1, %g2, %g3
+  1020:   01 00 00 00  nop
+  1024:   12 bf ff ff  bne       0x1020
+  1028:   10 bf ff ff  ba        0x1024
+  102c:   a0 02 00 09  add       %o0, %o1, %l0
+  1030:   0d bf ff ff  fbg       0x102c
+  1034:   d4 20 60 00  st        %o2, [%g1]
+  1038:   d4 4e 00 16  ldsb      [%i0+%l6], %o2
+  103c:   2a c2 80 03  brnz,a,pn %o2, 0x1048

--- a/test/data/assembly/sparc64.s
+++ b/test/data/assembly/sparc64.s
@@ -1,0 +1,6 @@
+# arch: sparc64
+# These tests are fetched from Capstone's test_sparc.c
+  1000:   81 a8 0a 24  fcmps %f0, %f4
+  1004:   89 a0 10 20  fstox %f0, %f4
+  1008:   89 a0 1a 60  fqtoi %f0, %f4
+  100c:   89 a0 00 e0  fnegq %f0, %f4

--- a/test/data/assembly/sparc64.s
+++ b/test/data/assembly/sparc64.s
@@ -1,4 +1,3 @@
-# arch: sparc64
 # These tests are fetched from Capstone's test_sparc.c
   1000:   81 a8 0a 24  fcmps %f0, %f4
   1004:   89 a0 10 20  fstox %f0, %f4

--- a/test/data/assembly/thumb.s
+++ b/test/data/assembly/thumb.s
@@ -1,16 +1,14 @@
-# arch: thumb
 # These tests are fetched from Capstone's test_arm.c
 # Thumb
+# PC-relative instructions are buggy in Capstone3, two lines are commented.
   80001000:   60 f9 1f 04  vld3.8  {d16, d17, d18}, [r0:0x40]
   80001004:   e0 f9 4f 07  vld4.16 {d16[1], d17[1], d18[1], d19[1]}, [r0]
   80001008:   70 47        bx      lr
-# PC-relative is buggy in Capstone3, skip it
-# 8000100a:   00 f0 10 e8 blx     #0x8000102c
+  ; 8000100a:   00 f0 10 e8 blx     #0x8000102c
   8000100a:   eb 46        mov     fp, sp
   8000100c:   83 b0        sub     sp, #0xc
   8000100e:   c9 68        ldr     r1, [r1, #0xc]
-# PC-relative is buggy in Capstone3, skip it
-# 80001010:   1f b1        cbz     r7, #0x8000101e
+  ; 80001010:   1f b1        cbz     r7, #0x8000101e
   80001010:   30 bf        wfi
   80001012:   af f3 20 84  cpsie.w f
   80001016:   52 f8 23 f0  ldr.w   pc, [r2, r3, lsl #2]
@@ -26,13 +24,14 @@
   80001012:   46 6c        ldr   r6, [r0, #0x44]
 
 # Thumb-2 & register named with numbers
+# An `iteet` instruction is removed to make the `it` instruction valid
   80001000:   4f f0 00 01  mov.w     r1, #0
   80001004:   bd e8 00 88  pop.w     {fp, pc}
   80001008:   d1 e8 00 f0  tbb       [r1, r0]
   8000100c:   18 bf        it        ne
-  8000100e:   ad bf        iteet     ge
-  80001010:   f3 ff 0b 0c  vdupne.8  d16, d11[1]
-  80001014:   86 f3 00 89  msr       cpsr_fc, r6
-  80001018:   80 f3 00 8c  msr       apsr_nzcvqg, r0
-  8000101c:   4f fa 99 f6  sxtb.w    r6, sb, ror #8
-  80001020:   d0 ff a2 01  vaddw.u16 q8, q8, d18
+  ; 8000100e:   ad bf        iteet     ge
+  8000100e:   f3 ff 0b 0c  vdupne.8  d16, d11[1]
+  80001012:   86 f3 00 89  msr       cpsr_fc, r6
+  80001016:   80 f3 00 8c  msr       apsr_nzcvqg, r0
+  8000101a:   4f fa 99 f6  sxtb.w    r6, sb, ror #8
+  8000101e:   d0 ff a2 01  vaddw.u16 q8, q8, d18

--- a/test/data/assembly/thumb.s
+++ b/test/data/assembly/thumb.s
@@ -1,0 +1,38 @@
+# arch: thumb
+# These tests are fetched from Capstone's test_arm.c
+# Thumb
+  80001000:   60 f9 1f 04  vld3.8  {d16, d17, d18}, [r0:0x40]
+  80001004:   e0 f9 4f 07  vld4.16 {d16[1], d17[1], d18[1], d19[1]}, [r0]
+  80001008:   70 47        bx      lr
+# PC-relative is buggy in Capstone3, skip it
+# 8000100a:   00 f0 10 e8 blx     #0x8000102c
+  8000100a:   eb 46        mov     fp, sp
+  8000100c:   83 b0        sub     sp, #0xc
+  8000100e:   c9 68        ldr     r1, [r1, #0xc]
+# PC-relative is buggy in Capstone3, skip it
+# 80001010:   1f b1        cbz     r7, #0x8000101e
+  80001010:   30 bf        wfi
+  80001012:   af f3 20 84  cpsie.w f
+  80001016:   52 f8 23 f0  ldr.w   pc, [r2, r3, lsl #2]
+
+# Thumb-mixed
+  80001000:   d1 e8 00 f0  tbb   [r1, r0]
+  80001004:   f0 24        movs  r4, #0xf0
+  80001006:   04 07        lsls  r4, r0, #0x1c
+  80001008:   1f 3c        subs  r4, #0x1f
+  8000100a:   f2 c0        stm   r0!, {r1, r4, r5, r6, r7}
+  8000100c:   00 00        movs  r0, r0
+  8000100e:   4f f0 00 01  mov.w r1, #0
+  80001012:   46 6c        ldr   r6, [r0, #0x44]
+
+# Thumb-2 & register named with numbers
+  80001000:   4f f0 00 01  mov.w     r1, #0
+  80001004:   bd e8 00 88  pop.w     {fp, pc}
+  80001008:   d1 e8 00 f0  tbb       [r1, r0]
+  8000100c:   18 bf        it        ne
+  8000100e:   ad bf        iteet     ge
+  80001010:   f3 ff 0b 0c  vdupne.8  d16, d11[1]
+  80001014:   86 f3 00 89  msr       cpsr_fc, r6
+  80001018:   80 f3 00 8c  msr       apsr_nzcvqg, r0
+  8000101c:   4f fa 99 f6  sxtb.w    r6, sb, ror #8
+  80001020:   d0 ff a2 01  vaddw.u16 q8, q8, d18

--- a/test/dynelf_test.rb
+++ b/test/dynelf_test.rb
@@ -16,7 +16,7 @@ class DynELFTest < MiniTest::Test
   include ::Pwnlib::ELF
 
   def setup
-    skip 'Only tested on linux' unless TTY::Platform.new.linux?
+    linux_only
   end
 
   # popen victim with specific libc.so.6

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -9,7 +9,7 @@ class RunnerTest < MiniTest::Test
   include ::Pwnlib::Context
 
   def setup
-    skip 'Runner can only be used on Linux' unless TTY::Platform.new.linux?
+    linux_only 'Runner can only be used on Linux'
   end
 
   def shellcraft

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require 'rainbow'
 require 'simplecov'
+require 'tty/platform'
 
 SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
   [SimpleCov::Formatter::HTMLFormatter]
@@ -18,6 +19,14 @@ module MiniTest
       super
       # Default to disable coloring for easier testing.
       Rainbow.enabled = false
+    end
+
+    def linux_only(msg = 'Only tested on Linux')
+      skip msg unless TTY::Platform.new.linux?
+    end
+
+    def skip_windows(msg = 'Skip on Windows')
+      skip msg if TTY::Platform.new.windows?
     end
 
     # Methods for hooking logger,

--- a/test/tubes/process_test.rb
+++ b/test/tubes/process_test.rb
@@ -85,6 +85,10 @@ class ProcessTest < MiniTest::Test
     # In cooked mode, tty should echo the input, so we can gets twice.
     assert_equal("Hi\r\n", cat.gets)
     assert_equal("Hi\r\n", cat.gets)
+    class << cat
+      # hook shutdown to silence the +cat: -: Input/output error+ message.
+      def shutdown; end
+    end
     cat.close
   end
 

--- a/test/tubes/process_test.rb
+++ b/test/tubes/process_test.rb
@@ -13,7 +13,7 @@ class ProcessTest < MiniTest::Test
   include ::Pwnlib::Context
 
   def setup
-    skip 'Skip on Windows' if TTY::Platform.new.windows?
+    skip_windows
   end
 
   def test_io
@@ -33,7 +33,8 @@ class ProcessTest < MiniTest::Test
   end
 
   def test_aslr
-    skip 'Only tested on linux' unless TTY::Platform.new.linux?
+    linux_only
+
     map1 = ::Pwnlib::Tubes::Process.new('cat /proc/self/maps', aslr: false).read
     map2 = ::Pwnlib::Tubes::Process.new(['cat', '/proc/self/maps'], aslr: false).read
     assert_match('/bin/cat', map1) # make sure it read something

--- a/test/tubes/serialtube_test.rb
+++ b/test/tubes/serialtube_test.rb
@@ -19,10 +19,6 @@ end
 class SerialTest < MiniTest::Test
   include ::Pwnlib::Tubes
 
-  def skip_windows
-    skip 'Not test tube/serialtube on Windows' if TTY::Platform.new.windows?
-  end
-
   def open_pair
     Open3.popen3('socat -d -d pty,raw,echo=0 pty,raw,echo=0') do |_i, _o, stderr, thread|
       devs = []


### PR DESCRIPTION
Architectures added:
`aarch64 arm mips mips64 powerpc64 sparc sparc64 thumb`

and `powerpc` added for asm only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/peter50216/pwntools-ruby/150)
<!-- Reviewable:end -->
