### PR TITLE
rubocop: Remove outdated Rails cop.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,9 +42,6 @@ Naming/HeredocDelimiterNaming:
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 
-Rails:
-  Enabled: false
-
 Style/AsciiComments:
   Enabled: false
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/peter50216/pwntools-ruby/187)
<!-- Reviewable:end -->
