### PR TITLE
Fix keyword argument errors raised in Ruby 2.8

### DIFF
--- a/lib/pwnlib/ext/helper.rb
+++ b/lib/pwnlib/ext/helper.rb
@@ -11,8 +11,8 @@ module Pwnlib
           .concat(m2.to_a)
           .each do |method, proxy_to|
             class_eval(<<-EOS, __FILE__, __LINE__ + 1)
-              def #{method}(*args, &block)
-              #{mod}.#{proxy_to}(self, *args, &block)
+              def #{method}(*args, **kwargs, &block)
+              #{mod}.#{proxy_to}(self, *args, **kwargs, &block)
               end
             EOS
           end

--- a/lib/pwnlib/shellcraft/generators/amd64/common/memcpy.rb
+++ b/lib/pwnlib/shellcraft/generators/amd64/common/memcpy.rb
@@ -25,7 +25,7 @@ module Pwnlib
           def memcpy(dst, src, n)
             cat "/* memcpy(#{pretty(dst)}, #{pretty(src)}, #{pretty(n)}) */"
             cat 'cld'
-            cat Common.setregs(rdi: dst, rsi: src, rcx: n)
+            cat Common.setregs({ rdi: dst, rsi: src, rcx: n })
             cat 'rep movsb'
           end
         end

--- a/lib/pwnlib/shellcraft/generators/amd64/common/setregs.rb
+++ b/lib/pwnlib/shellcraft/generators/amd64/common/setregs.rb
@@ -12,9 +12,9 @@ module Pwnlib
           # @overload setregs(reg_context, stack_allowed: true)
           #
           # @see Generators::X86::Common#setregs
-          def setregs(*args)
+          def setregs(*args, **kwargs)
             context.local(arch: :amd64) do
-              cat X86::Common.setregs(*args)
+              cat X86::Common.setregs(*args, **kwargs)
             end
           end
         end

--- a/lib/pwnlib/shellcraft/generators/amd64/linux/cat.rb
+++ b/lib/pwnlib/shellcraft/generators/amd64/linux/cat.rb
@@ -12,9 +12,9 @@ module Pwnlib
           # @overload cat(filename, fd: 1)
           #
           # @see Generators::X86::Linux#cat
-          def cat(*args)
+          def cat(*args, **kwargs)
             context.local(arch: :amd64) do
-              cat X86::Linux.cat(*args)
+              cat X86::Linux.cat(*args, **kwargs)
             end
           end
         end

--- a/lib/pwnlib/shellcraft/generators/amd64/linux/sh.rb
+++ b/lib/pwnlib/shellcraft/generators/amd64/linux/sh.rb
@@ -12,9 +12,9 @@ module Pwnlib
           # @overload sh(argv: false)
           #
           # @see Generators::X86::Linux#sh
-          def sh(*args)
+          def sh(**kwargs)
             context.local(arch: :amd64) do
-              cat X86::Linux.sh(*args)
+              cat X86::Linux.sh(**kwargs)
             end
           end
         end

--- a/lib/pwnlib/shellcraft/generators/helper.rb
+++ b/lib/pwnlib/shellcraft/generators/helper.rb
@@ -95,9 +95,9 @@ module Pwnlib
                 # Each method runs in an independent 'runner', so methods would not effect each other.
                 runner = Runner.new
                 method = instance_method(m).bind(runner)
-                define_singleton_method(m) do |*args|
+                define_singleton_method(m) do |*args, **kwargs|
                   runner.clear
-                  method.call(*args)
+                  method.call(*args, **kwargs)
                   runner.typesetting
                 end
               end

--- a/lib/pwnlib/shellcraft/generators/helper.rb
+++ b/lib/pwnlib/shellcraft/generators/helper.rb
@@ -97,7 +97,12 @@ module Pwnlib
                 method = instance_method(m).bind(runner)
                 define_singleton_method(m) do |*args, **kwargs|
                   runner.clear
-                  method.call(*args, **kwargs)
+                  # TODO(david942j): remove the check when we drop Ruby 2.6 support
+                  if kwargs.empty?
+                    method.call(*args)
+                  else
+                    method.call(*args, **kwargs)
+                  end
                   runner.typesetting
                 end
               end

--- a/lib/pwnlib/shellcraft/generators/i386/common/memcpy.rb
+++ b/lib/pwnlib/shellcraft/generators/i386/common/memcpy.rb
@@ -24,7 +24,7 @@ module Pwnlib
           def memcpy(dst, src, n)
             cat "/* memcpy(#{pretty(dst)}, #{pretty(src)}, #{pretty(n)}) */"
             cat 'cld'
-            cat Common.setregs(edi: dst, esi: src, ecx: n)
+            cat Common.setregs({ edi: dst, esi: src, ecx: n })
             cat 'rep movsb'
           end
         end

--- a/lib/pwnlib/shellcraft/generators/i386/common/setregs.rb
+++ b/lib/pwnlib/shellcraft/generators/i386/common/setregs.rb
@@ -12,9 +12,9 @@ module Pwnlib
           # @overload setregs(reg_context, stack_allowed: true)
           #
           # @see Generators::X86::Common#setregs
-          def setregs(*args)
+          def setregs(*args, **kwargs)
             context.local(arch: :i386) do
-              cat X86::Common.setregs(*args)
+              cat X86::Common.setregs(*args, **kwargs)
             end
           end
         end

--- a/lib/pwnlib/shellcraft/generators/i386/linux/cat.rb
+++ b/lib/pwnlib/shellcraft/generators/i386/linux/cat.rb
@@ -12,9 +12,9 @@ module Pwnlib
           # @overload cat(filename, fd: 1)
           #
           # @see Generators::X86::Linux#cat
-          def cat(*args)
+          def cat(*args, **kwargs)
             context.local(arch: :i386) do
-              cat X86::Linux.cat(*args)
+              cat X86::Linux.cat(*args, **kwargs)
             end
           end
         end

--- a/lib/pwnlib/shellcraft/generators/i386/linux/sh.rb
+++ b/lib/pwnlib/shellcraft/generators/i386/linux/sh.rb
@@ -12,9 +12,9 @@ module Pwnlib
           # @overload sh(argv: false)
           #
           # @see Generators::X86::Linux#sh
-          def sh(*args)
+          def sh(**kwargs)
             context.local(arch: :i386) do
-              cat X86::Linux.sh(*args)
+              cat X86::Linux.sh(**kwargs)
             end
           end
         end

--- a/lib/pwnlib/shellcraft/generators/x86/common/common.rb
+++ b/lib/pwnlib/shellcraft/generators/x86/common/common.rb
@@ -10,11 +10,11 @@ module Pwnlib
         module Common
           class << self
             def define_arch_dependent_method(method)
-              define_method(method) do |*args|
+              define_method(method) do |*args, **kwargs|
                 if context.arch == 'amd64'
-                  cat Amd64::Common.public_send(method, *args)
+                  cat Amd64::Common.public_send(method, *args, **kwargs)
                 elsif context.arch == 'i386'
-                  cat I386::Common.public_send(method, *args)
+                  cat I386::Common.public_send(method, *args, **kwargs)
                 end
               end
             end

--- a/lib/pwnlib/shellcraft/generators/x86/common/setregs.rb
+++ b/lib/pwnlib/shellcraft/generators/x86/common/setregs.rb
@@ -18,21 +18,21 @@ module Pwnlib
           #
           # @example
           #   context.arch = 'i386'
-          #   puts shellcraft.setregs(rax: 'ebx', ebx: 'ecx', ecx: 0x123)
-          #   #  mov rax, rbx
+          #   puts shellcraft.setregs({ eax: 'ebx', ebx: 'ecx', ecx: 0x123 })
+          #   #  mov eax, ebx
           #   #  mov ebx, ecx
           #   #  xor ecx, ecx
           #   #  mov cx, 0x123
           # @example
           #   context.arch = 'amd64'
-          #   puts shellcraft.setregs(rdi: 'rsi', rsi: 'rdi')
+          #   puts shellcraft.setregs({ rdi: 'rsi', rsi: 'rdi' })
           #   #  xchg rdi, rsi
           #
-          #   puts shellcraft.setregs(rax: -1)
+          #   puts shellcraft.setregs({ rax: -1 })
           #   #  push -1
           #   #  pop rax
           #
-          #   puts shellcraft.setregs({rax: -1}, stack_allowed: false)
+          #   puts shellcraft.setregs({ rax: -1 }, stack_allowed: false)
           #   #  mov rax, -1
           def setregs(reg_context, stack_allowed: true)
             abi = ::Pwnlib::ABI::ABI.default

--- a/lib/pwnlib/shellcraft/shellcraft.rb
+++ b/lib/pwnlib/shellcraft/shellcraft.rb
@@ -30,11 +30,11 @@ module Pwnlib
       #
       # With this method, +context.local(arch: 'amd64') { shellcraft.sh }+ will invoke
       # {Shellcraft::Generators::Amd64::Linux#sh}.
-      def method_missing(method, *args, &block)
+      def method_missing(method, *args, **kwargs, &block)
         mod = find_module_for(method)
         return super if mod.nil?
 
-        mod.public_send(method, *args, &block)
+        mod.public_send(method, *args, **kwargs, &block)
       end
 
       # For +respond_to?+.

--- a/test/asm_test.rb
+++ b/test/asm_test.rb
@@ -107,8 +107,8 @@ class AsmTest < MiniTest::Test
     assert_match(/meow/, err.message)
   end
 
-  def make_elf_file(*args)
-    elf = Asm.make_elf(*args)
+  def make_elf_file(data, **kwargs)
+    elf = Asm.make_elf(data, **kwargs)
     stream = StringIO.new(elf)
     [elf, ::ELFTools::ELFFile.new(stream)]
   end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -16,15 +16,15 @@ class LoggerTest < MiniTest::Test
   def setup
     @logger = ::Pwnlib::Logger::LoggerType.new
     class << @logger
-      def add(*args)
+      def add(*)
         clear
         super
         @logdev.string
       end
 
-      def indented(*args)
+      def indented(*, **)
         clear
-        super(*args)
+        super
         @logdev.string
       end
 

--- a/test/shellcraft/setregs_test.rb
+++ b/test/shellcraft/setregs_test.rb
@@ -15,27 +15,27 @@ class SetregsTest < MiniTest::Test
 
   def test_amd64
     context.local(arch: 'amd64') do
-      assert_equal(<<-'EOS', @shellcraft.setregs(rax: 1, rbx: 'rax'))
+      assert_equal(<<-'EOS', @shellcraft.setregs({ rax: 1, rbx: 'rax' }))
   mov rbx, rax
   push 1
   pop rax
       EOS
-      assert_equal(<<-'EOS', @shellcraft.setregs(rax: 'SYS_write', rbx: 'rax'))
+      assert_equal(<<-'EOS', @shellcraft.setregs({ rax: 'SYS_write', rbx: 'rax' }))
   mov rbx, rax
   push 1 /* (SYS_write) */
   pop rax
       EOS
-      assert_equal(<<-'EOS', @shellcraft.setregs(rax: 'rbx', rbx: 'rax', rcx: 'rbx'))
+      assert_equal(<<-'EOS', @shellcraft.setregs({ rax: 'rbx', rbx: 'rax', rcx: 'rbx' }))
   mov rcx, rbx
   xchg rax, rbx
       EOS
-      assert_equal(<<-'EOS', @shellcraft.setregs(rax: 1, rdx: 0))
+      assert_equal(<<-'EOS', @shellcraft.setregs({ rax: 1, rdx: 0 }))
   push 1
   pop rax
   cdq /* rdx=0 */
       EOS
       # issue #50
-      assert_equal(<<-'EOS', @shellcraft.setregs(rdi: :rax, rsi: :rdi))
+      assert_equal(<<-'EOS', @shellcraft.setregs({ rdi: :rax, rsi: :rdi }))
   mov rsi, rdi
   mov rdi, rax
       EOS
@@ -44,16 +44,16 @@ class SetregsTest < MiniTest::Test
 
   def test_i386
     context.local(arch: 'i386') do
-      assert_equal(<<-EOS, @shellcraft.setregs(eax: 1, ebx: 'eax'))
+      assert_equal(<<-EOS, @shellcraft.setregs({ eax: 1, ebx: 'eax' }))
   mov ebx, eax
   push 1
   pop eax
       EOS
-      assert_equal(<<-EOS, @shellcraft.setregs(eax: 'ebx', ebx: 'eax', ecx: 'ebx'))
+      assert_equal(<<-EOS, @shellcraft.setregs({ eax: 'ebx', ebx: 'eax', ecx: 'ebx' }))
   mov ecx, ebx
   xchg eax, ebx
       EOS
-      assert_equal(<<-'EOS', @shellcraft.setregs(eax: 1, edx: 0))
+      assert_equal(<<-'EOS', @shellcraft.setregs({ eax: 1, edx: 0 }))
   push 1
   pop eax
   cdq /* edx=0 */

--- a/test/util/packing_test.rb
+++ b/test/util/packing_test.rb
@@ -117,8 +117,8 @@ class PackingTest < MiniTest::Test
   def test_up_rand
     srand(217)
     [8, 16, 32, 64].each do |sz|
-      u = ->(*x) { ::Pwnlib::Util::Packing.public_send("u#{sz}", *x) }
-      p = ->(*x) { ::Pwnlib::Util::Packing.public_send("p#{sz}", *x) }
+      u = ->(*x, **k) { ::Pwnlib::Util::Packing.public_send("u#{sz}", *x, **k) }
+      p = ->(*x, **k) { ::Pwnlib::Util::Packing.public_send("p#{sz}", *x, **k) }
       100.times do
         limit = (1 << sz)
         val = rand(0...limit)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/14183

The keyword argument has to be explicitly used in Ruby 2.8.

closes #212

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/peter50216/pwntools-ruby/225)
<!-- Reviewable:end -->
