### PR TITLE
Drop Ruby 2.3

### DIFF
--- a/pwntools.gemspec
+++ b/pwntools.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.test_files    = Dir['test/**/*']
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.4'
 
   s.add_runtime_dependency 'crabstone', '~> 4'
   s.add_runtime_dependency 'dentaku', '>= 2.0.11', '< 3.5.0'


### PR DESCRIPTION
Set minimum Ruby version to 2.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/peter50216/pwntools-ruby/255)
<!-- Reviewable:end -->
